### PR TITLE
feat: add automatic GitHub release on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,34 @@ jobs:
 
       - run: npm ci
       - run: npm run build
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version
+        id: version
+        run: |
+          branch=${GITHUB_REF#refs/heads/}
+          if [[ "$branch" == release/* ]]; then
+            VERSION=${branch#release/}
+          else
+            VERSION=${GITHUB_SHA:0:7}
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: Release v${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Add automatic GitHub release creation when merging release branches to `main`.

### Changes

- Detects `release/*` branch names
- Creates GitHub release + tag (e.g., `v0.0.2`) on merge to `main`
- Generates release notes automatically
- Vercel auto-deploys from `main` (already configured)

### Release Flow

1. Create: `git checkout -b release/v1.0.0`
2. Merge: PR `release/v1.0.0` → `main`
3. CI runs → Build passes ✅
4. GitHub creates: Release + tag
5. Vercel deploys automatically