### PR TITLE
feat: enhance release workflow with backport automation to develop

### DIFF
--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -11,9 +11,9 @@ jobs:
       - name: Validate branch name
         run: |
           branch=${{ github.head_ref }}
-          pattern='^(main|develop|feature/|release/|hotfix/|docs/|chore/)'
+          pattern='^(main|develop|feature/|release/|hotfix/|docs/|chore/|backport/)'
           if ! echo "$branch" | grep -Eq "$pattern"; then
             echo "Branch name must follow Gitflow convention!"
-            echo "Valid: feature/123-desc, docs/update, hotfix/123-fix, chore/desc"
+            echo "Valid: feature/123-desc, docs/update, hotfix/123-fix, chore/desc, backport/v1.0.0"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI/CD
 
 on:
   push:
@@ -7,12 +7,15 @@ on:
       - '**.md'
       - 'docs/**'
       - '.gitignore'
+      - '.agents/**'
   pull_request:
+    types: [opened, synchronize, reopened, closed]
     branches: [main, develop]
     paths-ignore:
       - '**.md'
       - 'docs/**'
       - '.gitignore'
+      - '.agents/**'
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -20,9 +23,12 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write # Permiso necesario para que el bot pueda crear el PR
 
 jobs:
   build:
+    # Evitamos que el build corra cuando el PR se cierra (el push a main ya dispara un build)
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     
@@ -35,27 +41,35 @@ jobs:
           cache: 'npm'
 
       - run: npm ci
+      - run: npm run lint
       - run: npm run build
 
   release:
-    needs: build
+    # Ejecutar solo si:
+    # 1. Es un evento de PR
+    # 2. El PR fue cerrado
+    # 3. El PR fue mergeado
+    # 4. Se mergeó hacia la rama 'main'
+    # 5. La rama de origen comenzaba con 'release/'
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.base_ref == 'main' && startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     
     steps:
+      # Hacemos checkout explícito de 'main' ya que el PR se acaba de mergear ahí
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: main
 
       - name: Extract version
         id: version
         run: |
-          branch=${GITHUB_REF#refs/heads/}
-          if [[ "$branch" == release/* ]]; then
-            VERSION=${branch#release/v}
-          else
-            VERSION=${GITHUB_SHA:0:7}
-          fi
+          # github.head_ref es la rama origen, ej: release/v1.0.0 o release/1.0.0
+          BRANCH="${{ github.head_ref }}"
+          # Quitamos el prefijo 'release/'
+          VERSION=${BRANCH#release/}
+          # Si le pusieron una 'v' al número (ej v1.0.0), la quitamos para que no quede 'vv1.0.0'
+          VERSION=${VERSION#v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
@@ -67,3 +81,25 @@ jobs:
           draft: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Automate Backport PR to develop
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BACKPORT_BRANCH="backport/v${VERSION}"
+          
+          # Configuramos un usuario de git genérico de actions bot
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          # Creamos la rama desde el estado actual de main y la subimos
+          git checkout -b "$BACKPORT_BRANCH"
+          git push -u origin "$BACKPORT_BRANCH"
+          
+          # Usamos GitHub CLI para crear el PR contra develop
+          gh pr create \
+            --base develop \
+            --head "$BACKPORT_BRANCH" \
+            --title "chore: backport release v${VERSION} to develop" \
+            --body "Este PR fue generado automáticamente al lanzar el release \`v${VERSION}\`. Mergea este PR para mantener \`develop\` sincronizado con \`main\` y actualizar el historial."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/components/AboutSection.tsx
+++ b/components/AboutSection.tsx
@@ -22,7 +22,7 @@ const AboutSection: React.FC<AboutSectionProps> = ({ data }) => {
         {/* Reseña */}
         <div className="text-center max-w-4xl mx-auto">
           <p className="text-lg md:text-xl text-slate-300 italic leading-relaxed">
-            "{data.review}"
+            &ldquo;{data.review}&rdquo;
           </p>
         </div>
 

--- a/components/ScrollToTopButton.tsx
+++ b/components/ScrollToTopButton.tsx
@@ -43,7 +43,7 @@ const ScrollToTopButton: React.FC = () => {
           marginTop: `-${size / 2}px`,
           marginLeft: `-${size / 2}px`,
           '--transform-end': `translate(${x}px, ${y}px)`,
-        } as React.CSSProperties & { [key: string]: any },
+        } as React.CSSProperties & Record<string, string | number>,
       };
     });
     setParticles(newParticles);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,9 +2,13 @@ import js from '@eslint/js';
 import tseslint from '@typescript-eslint/eslint-plugin';
 import tsparser from '@typescript-eslint/parser';
 import react from 'eslint-plugin-react';
+import globals from 'globals';
 
 export default [
   js.configs.recommended,
+  {
+    ignores: ['dist/**', 'node_modules/**'],
+  },
   {
     files: ['**/*.{ts,tsx}'],
     plugins: {
@@ -20,12 +24,17 @@ export default [
         ecmaVersion: 'latest',
         sourceType: 'module',
       },
+      globals: {
+        ...globals.browser,
+        ...globals.es2021,
+      },
     },
     rules: {
       ...react.configs.recommended.rules,
       ...tseslint.configs.recommended.rules,
       'react/react-in-jsx-scope': 'off',
       '@typescript-eslint/no-unused-vars': 'warn',
+      'no-undef': 'off',
     },
     settings: {
       react: {

--- a/types.ts
+++ b/types.ts
@@ -1,5 +1,3 @@
-import type React from 'react';
-
 export interface LinkItem {
   title: string;
   url: string;


### PR DESCRIPTION
## Summary
- Add `backport/` to valid branch name patterns in branch-check workflow
- Rename CI workflow to CI/CD for clarity
- Add `.agents/**` to paths-ignore in CI workflow
- Add permission for pull-requests write access
- Implement automatic backport PR creation when release branches are merged to main
- Improve release job logic to only trigger on merged PRs targeting main from release/* branches
- Fix version extraction to handle both `release/v1.0.0` and `release/1.0.0` formats