### PR TITLE
test: add component tests for Icon component (issue #24)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,12 @@ npm test -- <path/to/test/file>
 
 As mentioned above, there are no tests in this project. When adding features or fixing bugs, consider adding tests to ensure the stability of the codebase. Use Vitest as the testing framework and React Testing Library for testing components.
 
+### Test Code Quality
+
+- **Don't assume code is correct**: If tests fail, the implementation code might be wrong
+- **Review the code**: When tests fail, analyze the implementation to determine if the bug is in the test or the code
+- **Ask before changing implementation**: If you find a bug in the code, ask the user before fixing it
+
 ## Workflow
 
 ### Task Management

--- a/components/ui/Icon.test.tsx
+++ b/components/ui/Icon.test.tsx
@@ -1,0 +1,59 @@
+import { render } from '@testing-library/react'
+import { Icon } from './Icon'
+import { describe, it, expect } from 'vitest'
+
+describe('Icon', () => {
+  it('should Render instagram icon', () => {
+    const { container } = render(<Icon name="instagram" />)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+  })
+
+  it('should Render youtube icon', () => {
+    const { container } = render(<Icon name="youtube" />)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+  })
+
+  it('should render spotify icon', () => {
+    const { container } = render(<Icon name="spotify" />)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+  })
+
+  it('should apply size prop', () => {
+    const { container } = render(<Icon name="instagram" size={48} />)
+    const span = container.querySelector('span')
+    expect(span).toHaveStyle({ width: '48px', height: '48px' })
+  })
+
+  it('should apply className prop', () => {
+    const { container } = render(<Icon name="instagram" className="custom-class" />)
+    const span = container.querySelector('span')
+    expect(span).toHaveClass('custom-class')
+  })
+
+  it('should have default size of 24', () => {
+    const { container } = render(<Icon name="instagram" />)
+    const span = container.querySelector('span')
+    expect(span).toHaveStyle({ width: '24px', height: '24px' })
+  })
+
+  it('should have default strokeWidth of 2', () => {
+    const { container } = render(<Icon name="instagram" />)
+    const svg = container.querySelector('svg')
+    expect(svg).toHaveAttribute('stroke-width', '2')
+  })
+
+  it('should apply custom strokeWidth', () => {
+    const { container } = render(<Icon name="instagram" strokeWidth={4} />)
+    const svg = container.querySelector('svg')
+    expect(svg).toHaveAttribute('stroke-width', '4')
+  })
+
+  it('should have aria-hidden attribute on container', () => {
+    const { container } = render(<Icon name="instagram" />)
+    const span = container.querySelector('span')
+    expect(span).toHaveAttribute('aria-hidden', 'true')
+  })
+})


### PR DESCRIPTION
## Summary
Add 9 component tests for Icon component:

### Tests
- Render instagram, youtube, spotify icons
- Size prop application
- className prop application  
- Default size (24) and strokeWidth (2)
- Custom strokeWidth
- aria-hidden accessibility attribute

## AGENTS.md Update
Add test code quality guidelines:
- Don't assume code is correct
- Review code when tests fail
- Ask before changing implementation

## Verification
- ✓ All 46 tests passing
- ✓ Build passing
- ✓ Lint passing

Closes #24