### PR TITLE
ci: add test step to CI pipeline (issue #25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
 
       - run: npm install
       - run: npm run lint
+      - run: npm test
       - run: npm run build
 
   release:


### PR DESCRIPTION
## Summary
Add test step to GitHub Actions CI pipeline.

### Changes
- Add 
> correla-voz-web@1.0.0 test
> vitest


[1m[46m RUN [49m[22m [36mv4.1.1 [39m[90m/Users/earias/code/Correla-Voz---web[39m


[2m Test Files [22m [1m[32m5 passed[39m[22m[90m (5)[39m
[2m      Tests [22m [1m[32m46 passed[39m[22m[90m (46)[39m
[2m   Start at [22m 16:03:38
[2m   Duration [22m 1.06s[2m (transform 265ms, setup 306ms, import 603ms, tests 233ms, environment 2.96s)[22m to CI workflow
- Pipeline now runs: lint → test → build

### Verification
- ✓ All 46 tests passing
- ✓ Build passing
- ✓ Lint passing

Closes #25