### PR TITLE
chore: add coverage folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ dist-ssr
 # Caches
 .eslintcache
 *.tsbuildinfo
+
+# Test coverage
+coverage


### PR DESCRIPTION
## Summary
- Add `coverage/` folder to `.gitignore` to exclude test coverage reports from version control
- Follows existing pattern for generated artifacts (like `.eslintcache`, `dist`)