### PR TITLE
feat(design-system): Fase 3 - Refactor de componentes existentes

### DIFF
--- a/components/AboutSection.tsx
+++ b/components/AboutSection.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import Section from './Section';
+import { Card } from './ui/card';
 import type { AboutSectionData, HistoryContentBlock } from '../types';
 
 interface AboutSectionProps {
@@ -53,7 +54,7 @@ const AboutSection: React.FC<AboutSectionProps> = ({ data }) => {
         </div>
 
         {/* Ensayos */}
-        <div className="max-w-2xl mx-auto bg-slate-900/60 carnival-border p-8 text-center relative rounded-xl">
+        <Card className="max-w-2xl mx-auto carnival-border p-8 text-center relative">
             <h4 className="font-bold text-xl text-teal-300 mb-4 flex items-center justify-center">
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -76,7 +77,7 @@ const AboutSection: React.FC<AboutSectionProps> = ({ data }) => {
             </a>
 
             <p className="font-semibold text-white animate-pulse pt-4 border-t border-slate-700/50">{data.nextRehearsalInfo}</p>
-        </div>
+        </Card>
       </div>
     </Section>
   );

--- a/components/CalendarSection.tsx
+++ b/components/CalendarSection.tsx
@@ -1,6 +1,8 @@
 
 import React, { useState, useMemo } from 'react';
 import Section from './Section';
+import { Card } from './ui/card';
+import { Badge } from './ui/badge';
 import type { EventItem } from '../types';
 import EventModal from './EventModal';
 
@@ -64,10 +66,11 @@ const CalendarSection: React.FC<CalendarSectionProps> = ({ events }) => {
             processedEvents.map((event, index) => {
               const isNextEvent = event === nextEvent;
               return (
-                <button
+                <Card
+                  as="button"
                   key={`${event.date}-${event.title}-${index}`}
                   onClick={() => setSelectedEvent(event)}
-                  className={`w-full text-left flex items-center bg-slate-800/50 p-4 rounded-lg border transition-all duration-300 cursor-pointer hover:bg-slate-800 focus:outline-none relative overflow-hidden ${
+                  className={`w-full text-left flex items-center p-4 transition-all duration-300 cursor-pointer hover:bg-slate-800 focus:outline-none relative overflow-hidden ${
                     isNextEvent
                       ? 'border-teal-400 ring-2 ring-teal-400 ring-offset-2 ring-offset-black'
                       : 'border-slate-700 hover:border-red-500 focus:ring-2 focus:ring-red-500'
@@ -75,9 +78,9 @@ const CalendarSection: React.FC<CalendarSectionProps> = ({ events }) => {
                   aria-label={`Ver detalles para ${event.title}`}
                 >
                   {isNextEvent && (
-                     <span className="absolute top-0 right-0 bg-teal-400 text-black text-xs font-bold px-2 py-1 rounded-bl-lg">
+                     <Badge className="absolute top-0 right-0 rounded-none rounded-bl-lg px-2 py-1">
                        Próximo
-                     </span>
+                     </Badge>
                   )}
                   <div className="flex flex-col items-center justify-center text-center pr-4 border-r border-slate-600">
                     <span className="text-3xl font-bold text-red-500">{event.day}</span>
@@ -92,14 +95,14 @@ const CalendarSection: React.FC<CalendarSectionProps> = ({ events }) => {
                       {event.time}
                     </div>
                   )}
-                </button>
+                </Card>
               );
             })
           ) : (
-            <div className="text-center text-slate-400 bg-slate-800/50 p-6 rounded-lg border border-slate-700">
+            <Card className="text-center text-slate-400 p-6 border-slate-700">
               <p>No hay presentaciones programadas próximamente.</p>
               <p className="text-sm mt-2">¡Vuelve a consultar pronto para enterarte de las novedades!</p>
-            </div>
+            </Card>
           )}
         </div>
       </Section>

--- a/components/LinksSection.tsx
+++ b/components/LinksSection.tsx
@@ -1,5 +1,6 @@
 
 import Section from './Section';
+import { Card } from './ui/card';
 import { Icon } from './ui/Icon';
 import type { LinkItem } from '../types';
 
@@ -12,12 +13,13 @@ function LinksSection({ links }: LinksSectionProps) {
     <Section title="Conócenos Más">
       <div className="flex flex-wrap justify-center gap-4 md:gap-6">
         {links.map((link) => (
-          <a
+          <Card
+            as="a"
             key={link.title}
             href={link.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="group bg-slate-800/50 border border-slate-700 rounded-lg p-4 transition-all duration-300 ease-in-out transform hover:-translate-y-1 hover:border-red-500 hover:bg-red-900/30 w-40 md:w-60"
+            className="group p-4 transition-all duration-300 ease-in-out transform hover:-translate-y-1 hover:border-red-500 hover:bg-red-900/30 w-40 md:w-60"
           >
             <div className="flex flex-col items-center justify-center h-full text-center">
               <div className="text-slate-300 group-hover:text-red-500 transition-colors duration-300">
@@ -27,7 +29,7 @@ function LinksSection({ links }: LinksSectionProps) {
                 {link.title}
               </span>
             </div>
-          </a>
+          </Card>
         ))}
       </div>
     </Section>

--- a/components/PhotosSection.tsx
+++ b/components/PhotosSection.tsx
@@ -1,6 +1,8 @@
 
 import React, { useRef, useState, useEffect, useCallback } from 'react';
 import Section from './Section';
+import { Card } from './ui/card';
+import { Button } from './ui/button';
 import type { AlbumItem } from '../types';
 
 const monthMap: { [key: string]: number } = {
@@ -156,26 +158,28 @@ const PhotosSection: React.FC<PhotosSectionProps> = ({ albums }) => {
         </div>
       ) : (
         <div className="relative group/carousel">
-          <button
+          <Button
+            size="icon"
             onClick={() => scroll('left')}
             aria-label="Álbum anterior"
             disabled={!canScrollLeft}
-            className="absolute top-1/2 left-2 transform -translate-y-1/2 w-12 h-12 bg-red-600/80 hover:bg-red-600 rounded-full text-white shadow-lg z-10 hidden md:flex items-center justify-center transition-all duration-300 opacity-0 group-hover/carousel:opacity-100 disabled:opacity-0 disabled:cursor-not-allowed"
+            className="absolute top-1/2 left-2 transform -translate-y-1/2 w-12 h-12 rounded-full bg-red-600/80 hover:bg-red-600 shadow-lg z-10 hidden md:flex opacity-0 group-hover/carousel:opacity-100 disabled:opacity-0"
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-          </button>
+          </Button>
 
           <div 
             ref={scrollContainerRef}
             className="flex space-x-4 md:space-x-6 py-4 -mx-4 px-4 overflow-x-auto scroll-smooth scrollbar-hide snap-x snap-mandatory"
           >
             {albums.map((album, index) => (
-              <a
+              <Card
+                as="a"
                 key={`${album.title}-${index}`}
                 href={album.albumUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group block bg-slate-800 rounded-lg overflow-hidden shadow-lg hover:shadow-red-500/20 transition-all duration-300 transform hover:-translate-y-1 border-2 border-transparent hover:border-red-500 snap-start flex-shrink-0 w-5/6 sm:w-1/2 md:w-1/3 lg:w-1/4"
+                className="group block overflow-hidden hover:shadow-red-500/20 transition-all duration-300 transform hover:-translate-y-1 border-2 border-transparent hover:border-red-500 snap-start flex-shrink-0 w-5/6 sm:w-1/2 md:w-1/3 lg:w-1/4"
               >
                 <div className="relative aspect-[4/3] overflow-hidden">
                   <img src={album.imageUrl} alt={album.title} className="w-full h-full object-cover transition-transform duration-500 ease-in-out group-hover:scale-110 group-hover:-rotate-1" />
@@ -190,18 +194,19 @@ const PhotosSection: React.FC<PhotosSectionProps> = ({ albums }) => {
                     )}
                   </div>
                 </div>
-              </a>
+              </Card>
             ))}
           </div>
           
-          <button
+          <Button
+            size="icon"
             onClick={() => scroll('right')}
             aria-label="Siguiente álbum"
             disabled={!canScrollRight}
-            className="absolute top-1/2 right-2 transform -translate-y-1/2 w-12 h-12 bg-red-600/80 hover:bg-red-600 rounded-full text-white shadow-lg z-10 hidden md:flex items-center justify-center transition-all duration-300 opacity-0 group-hover/carousel:opacity-100 disabled:opacity-0 disabled:cursor-not-allowed"
+            className="absolute top-1/2 right-2 transform -translate-y-1/2 w-12 h-12 rounded-full bg-red-600/80 hover:bg-red-600 shadow-lg z-10 hidden md:flex opacity-0 group-hover/carousel:opacity-100 disabled:opacity-0"
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
-          </button>
+          </Button>
         </div>
       )}
     </Section>

--- a/components/ScrollToTopButton.tsx
+++ b/components/ScrollToTopButton.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { Button } from './ui/button';
 
 interface Particle {
   id: number;
@@ -123,10 +124,10 @@ const ScrollToTopButton: React.FC = () => {
   return (
     <>
       <div className="fixed bottom-5 right-5 z-40">
-        <button
-          type="button"
+        <Button
+          size="icon"
           onClick={handleClick}
-          className={`w-12 h-12 flex items-center justify-center rounded-full bg-red-600 text-white shadow-lg hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-slate-900 transition-all duration-300 ease-in-out ${(isVisible && !isAnimating) ? 'opacity-100 scale-100' : 'opacity-0 scale-90 pointer-events-none'
+          className={`w-12 h-12 rounded-full shadow-lg transition-all duration-300 ease-in-out ${(isVisible && !isAnimating) ? 'opacity-100 scale-100' : 'opacity-0 scale-90 pointer-events-none'
             }`}
           aria-label="Volver arriba"
           title="Volver arriba"
@@ -135,7 +136,7 @@ const ScrollToTopButton: React.FC = () => {
             <path d="M12 19V5"></path>
             <polyline points="5 12 12 5 19 12"></polyline>
           </svg>
-        </button>
+        </Button>
       </div>
 
       {isAnimating && (

--- a/src/test/components/AboutSection.test.tsx
+++ b/src/test/components/AboutSection.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import AboutSection from '../../../components/AboutSection'
+import type { AboutSectionData } from '../../../types'
+
+beforeAll(() => {
+  global.IntersectionObserver = class IntersectionObserver {
+    constructor() {}
+    disconnect() {}
+    observe() {}
+    unobserve() {}
+    takeRecords() {
+      return []
+    }
+  } as unknown as typeof IntersectionObserver
+})
+
+const mockData: AboutSectionData = {
+  review: 'An amazing choir with a unique sound.',
+  history: [
+    { type: 'text', content: 'Founded in 2010, we started as a small group.' },
+    { type: 'text', content: 'We have grown to over 30 members.' },
+  ],
+  rehearsalSchedule: 'Every Tuesday at 7 PM',
+  rehearsalLocation: 'Cultural Center',
+  rehearsalLocationUrl: 'https://maps.example.com',
+  nextRehearsalInfo: 'Next rehearsal: May 15th',
+}
+
+describe('AboutSection', () => {
+  it('renders the review text', () => {
+    render(<AboutSection data={mockData} />)
+
+    expect(screen.getByText(/An amazing choir with a unique sound/)).toBeInTheDocument()
+  })
+
+  it('renders history text blocks', () => {
+    render(<AboutSection data={mockData} />)
+
+    expect(screen.getByText('Founded in 2010, we started as a small group.')).toBeInTheDocument()
+    expect(screen.getByText('We have grown to over 30 members.')).toBeInTheDocument()
+  })
+
+  it('renders rehearsal schedule and location', () => {
+    render(<AboutSection data={mockData} />)
+
+    expect(screen.getByText('Every Tuesday at 7 PM')).toBeInTheDocument()
+    expect(screen.getByText('Cultural Center')).toBeInTheDocument()
+    expect(screen.getByText('Next rehearsal: May 15th')).toBeInTheDocument()
+  })
+})

--- a/src/test/components/CalendarSection.test.tsx
+++ b/src/test/components/CalendarSection.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import CalendarSection from '../../../components/CalendarSection'
+import type { EventItem } from '../../../types'
+
+beforeAll(() => {
+  global.IntersectionObserver = class IntersectionObserver {
+    constructor() {}
+    disconnect() {}
+    observe() {}
+    unobserve() {}
+    takeRecords() {
+      return []
+    }
+  } as unknown as typeof IntersectionObserver
+})
+
+const createFutureDate = (daysFromNow: number = 7): { date: string; day: string } => {
+  const d = new Date()
+  d.setDate(d.getDate() + daysFromNow)
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return {
+    date: `${year}-${month}-${day}`,
+    day: String(d.getDate()),
+  }
+}
+
+const createEvent = (overrides: Partial<EventItem> = {}): EventItem => {
+  const future = createFutureDate()
+  return {
+    date: future.date,
+    day: future.day,
+    month: 'Dic',
+    title: 'Test Event',
+    location: 'Test Location',
+    description: 'Test Description',
+    ...overrides,
+  }
+}
+
+describe('CalendarSection', () => {
+  it('renders event titles and locations', () => {
+    const events = [
+      createEvent({ title: 'Concert A', location: 'Theater X' }),
+      createEvent({ title: 'Concert B', location: 'Hall Y' }),
+    ]
+    render(<CalendarSection events={events} />)
+
+    expect(screen.getByText('Concert A')).toBeInTheDocument()
+    expect(screen.getByText('Theater X')).toBeInTheDocument()
+    expect(screen.getByText('Concert B')).toBeInTheDocument()
+    expect(screen.getByText('Hall Y')).toBeInTheDocument()
+  })
+
+  it('shows "Próximo" badge for the next upcoming event', () => {
+    const futureDate = new Date()
+    futureDate.setDate(futureDate.getDate() + 7)
+    const year = futureDate.getFullYear()
+    const month = String(futureDate.getMonth() + 1).padStart(2, '0')
+    const day = String(futureDate.getDate()).padStart(2, '0')
+
+    const events = [
+      createEvent({
+        date: `${year}-${month}-${day}`,
+        day: String(futureDate.getDate()),
+        title: 'Future Concert',
+      }),
+    ]
+    render(<CalendarSection events={events} />)
+
+    expect(screen.getByText('Próximo')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no events are provided', () => {
+    render(<CalendarSection events={[]} />)
+
+    expect(screen.getByText('No hay presentaciones programadas próximamente.')).toBeInTheDocument()
+  })
+
+  it('opens modal when an event is clicked', async () => {
+    const events = [
+      createEvent({ title: 'Clickable Event', description: 'Event Details' }),
+    ]
+    render(<CalendarSection events={events} />)
+
+    const eventButton = screen.getByLabelText('Ver detalles para Clickable Event')
+    await userEvent.click(eventButton)
+
+    expect(screen.getByText('Event Details')).toBeInTheDocument()
+  })
+})

--- a/src/test/components/LinksSection.test.tsx
+++ b/src/test/components/LinksSection.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import LinksSection from '../../../components/LinksSection'
+import type { LinkItem } from '../../../types'
+
+beforeAll(() => {
+  global.IntersectionObserver = class IntersectionObserver {
+    constructor() {}
+    disconnect() {}
+    observe() {}
+    unobserve() {}
+    takeRecords() {
+      return []
+    }
+  } as unknown as typeof IntersectionObserver
+})
+
+const mockLinks: LinkItem[] = [
+  { title: 'YouTube', url: 'https://youtube.com/test', iconName: 'youtube' },
+  { title: 'Spotify', url: 'https://spotify.com/test', iconName: 'spotify' },
+  { title: 'Instagram', url: 'https://instagram.com/test', iconName: 'instagram' },
+]
+
+describe('LinksSection', () => {
+  it('renders link titles', () => {
+    render(<LinksSection links={mockLinks} />)
+
+    expect(screen.getByText('YouTube')).toBeInTheDocument()
+    expect(screen.getByText('Spotify')).toBeInTheDocument()
+    expect(screen.getByText('Instagram')).toBeInTheDocument()
+  })
+
+  it('renders links with correct hrefs', () => {
+    render(<LinksSection links={mockLinks} />)
+
+    expect(screen.getByText('YouTube').closest('a')).toHaveAttribute(
+      'href',
+      'https://youtube.com/test'
+    )
+    expect(screen.getByText('Spotify').closest('a')).toHaveAttribute(
+      'href',
+      'https://spotify.com/test'
+    )
+  })
+})

--- a/src/test/components/PhotosSection.test.tsx
+++ b/src/test/components/PhotosSection.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import PhotosSection from '../../../components/PhotosSection'
+import type { AlbumItem } from '../../../types'
+
+beforeAll(() => {
+  global.IntersectionObserver = class IntersectionObserver {
+    constructor() {}
+    disconnect() {}
+    observe() {}
+    unobserve() {}
+    takeRecords() {
+      return []
+    }
+  } as unknown as typeof IntersectionObserver
+})
+
+const mockAlbums: AlbumItem[] = [
+  {
+    title: 'Album One',
+    imageUrl: 'https://example.com/one.jpg',
+    albumUrl: 'https://photos.google.com/one',
+    date: '15 de Marzo, 2024',
+  },
+  {
+    title: 'Album Two',
+    imageUrl: 'https://example.com/two.jpg',
+    albumUrl: 'https://photos.google.com/two',
+    date: '20 de Abril, 2024',
+  },
+]
+
+describe('PhotosSection', () => {
+  it('renders album titles', () => {
+    render(<PhotosSection albums={mockAlbums} />)
+
+    expect(screen.getByText('Album One')).toBeInTheDocument()
+    expect(screen.getByText('Album Two')).toBeInTheDocument()
+  })
+
+  it('renders album links with correct hrefs', () => {
+    render(<PhotosSection albums={mockAlbums} />)
+
+    expect(screen.getByText('Album One').closest('a')).toHaveAttribute(
+      'href',
+      'https://photos.google.com/one'
+    )
+    expect(screen.getByText('Album Two').closest('a')).toHaveAttribute(
+      'href',
+      'https://photos.google.com/two'
+    )
+  })
+
+  it('shows empty state when no albums are provided', () => {
+    render(<PhotosSection albums={[]} />)
+
+    expect(
+      screen.getByText('No hay álbumes de fotos para mostrar en este momento.')
+    ).toBeInTheDocument()
+  })
+})

--- a/src/test/components/ScrollToTopButton.test.tsx
+++ b/src/test/components/ScrollToTopButton.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import ScrollToTopButton from '../../../components/ScrollToTopButton'
+
+beforeAll(() => {
+  global.IntersectionObserver = class IntersectionObserver {
+    constructor() {}
+    disconnect() {}
+    observe() {}
+    unobserve() {}
+    takeRecords() {
+      return []
+    }
+  } as unknown as typeof IntersectionObserver
+})
+
+describe('ScrollToTopButton', () => {
+  it('is initially hidden', () => {
+    render(<ScrollToTopButton />)
+
+    const button = screen.getByLabelText('Volver arriba')
+    expect(button).toHaveClass('opacity-0')
+    expect(button).toHaveClass('pointer-events-none')
+  })
+
+  it('becomes visible after scrolling down', () => {
+    Object.defineProperty(window, 'scrollY', { value: 1000, writable: true })
+    Object.defineProperty(window, 'innerHeight', { value: 800, writable: true })
+
+    render(<ScrollToTopButton />)
+
+    // Simulate scroll event wrapped in act
+    act(() => {
+      window.dispatchEvent(new Event('scroll'))
+    })
+
+    const button = screen.getByLabelText('Volver arriba')
+    expect(button).toHaveClass('opacity-100')
+    expect(button).toHaveClass('scale-100')
+  })
+})


### PR DESCRIPTION
## Cambios

Esta PR implementa la Fase 3 (final) del Design System MVP (#43).

### Tareas completadas

- [x] Refactorizar `CalendarSection.tsx` para usar Card + Badge
- [x] Refactorizar `LinksSection.tsx` para usar Card
- [x] Refactorizar `PhotosSection.tsx` para usar Card + Button
- [x] Refactorizar `AboutSection.tsx` para usar Card
- [x] Refactorizar `ScrollToTopButton.tsx` para usar Button
- [x] Verificar build, lint, y cero regresiones

### Componentes refactorizados

- **CalendarSection**: Reemplazado markup ad-hoc por Card + Badge. Preserva modal de eventos.
- **LinksSection**: Reemplazado cards sueltos por componente Card.
- **PhotosSection**: Reemplazado cards y botones por Card + Button.
- **AboutSection**: Reemplazado bloque de ensayos por Card.
- **ScrollToTopButton**: Reemplazado botón nativo por Button size=icon.

### Tests

- 14 tests nuevos (approval tests para cada sección refactorizada)
- 107 tests totales pasando

### Verificación

- [x] Build pasa (`npm run build`)
- [x] Lint pasa (`npm run lint`)
- [x] Tests pasan (`npm test`) - 107 tests totales

### Nota

Pequeñas diferencias visuales esperadas: los componentes ahora usan tokens semánticos (`bg-surface`, `border-surface-border`) en vez de valores hardcodeados (`bg-slate-800/50`, `border-slate-700`). Esto unifica el diseño pero puede cambiar ligeramente la apariencia.

### Issues relacionados

Closes #46
Closes #43