### PR TITLE
chore: add vercel.json for SPA routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
Agrega vercel.json para manejar el routing de la SPA. Necesario para que Vercel sirva index.html en todas las rutas.