### PR TITLE
fix: update domain to murgacorrelavoz.com.ar

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,14 +9,14 @@
   <!-- SEO Meta Tags -->
   <meta name="description" content="Somos Correla Voz, una murga de Tandil. Hacemos que se prendan los bombos, el baile y la garganta para decir lo que otros callan. Somos la chispa que enciende el fuego del carnaval." />
   <meta name="keywords" content="murga, Tandil, carnaval, Correla Voz, cultura popular, baile, música" />
-  <link rel="canonical" href="https://correlavoz.com.ar" />
+  <link rel="canonical" href="https://murgacorrelavoz.com.ar" />
   <meta name="robots" content="index, follow" />
 
   <!-- Open Graph Tags -->
   <meta property="og:title" content="Correla Voz — Murga de Tandil" />
   <meta property="og:description" content="Somos Correla Voz, una murga de Tandil. Hacemos que se prendan los bombos, el baile y la garganta para decir lo que otros callan. Somos la chispa que enciende el fuego del carnaval." />
-  <meta property="og:image" content="https://correlavoz.com.ar/images/albums/cumplecorso2025.jpg" />
-  <meta property="og:url" content="https://correlavoz.com.ar" />
+  <meta property="og:image" content="https://murgacorrelavoz.com.ar/images/albums/cumplecorso2025.jpg" />
+  <meta property="og:url" content="https://murgacorrelavoz.com.ar" />
   <meta property="og:type" content="website" />
   <meta property="og:locale" content="es_AR" />
   <meta property="og:site_name" content="Correla Voz" />
@@ -25,7 +25,7 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Correla Voz — Murga de Tandil" />
   <meta name="twitter:description" content="Somos Correla Voz, una murga de Tandil. Hacemos que se prendan los bombos, el baile y la garganta para decir lo que otros callan. Somos la chispa que enciende el fuego del carnaval." />
-  <meta name="twitter:image" content="https://correlavoz.com.ar/images/albums/cumplecorso2025.jpg" />
+  <meta name="twitter:image" content="https://murgacorrelavoz.com.ar/images/albums/cumplecorso2025.jpg" />
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/src/test/integration/meta-tags.test.tsx
+++ b/src/test/integration/meta-tags.test.tsx
@@ -38,7 +38,7 @@ describe('Meta Tags', () => {
 
     it('has canonical link', () => {
       const href = getLinkHref(indexHtml, 'canonical')
-      expect(href).toBe('https://correlavoz.com.ar')
+      expect(href).toBe('https://murgacorrelavoz.com.ar')
     })
 
     it('has robots meta tag', () => {
@@ -70,7 +70,7 @@ describe('Meta Tags', () => {
 
     it('has og:url', () => {
       const content = getMetaContent(indexHtml, 'property', 'og:url')
-      expect(content).toBe('https://correlavoz.com.ar')
+      expect(content).toBe('https://murgacorrelavoz.com.ar')
     })
 
     it('has og:type', () => {


### PR DESCRIPTION
## Summary
- Corregido el dominio en todos los meta tags: `correlavoz.com.ar` → `murgacorrelavoz.com.ar`
- Afecta: canonical, og:url, og:image, twitter:image en index.html
- Tests actualizados al dominio correcto