### PR TITLE
chore: add sitemap.xml and robots.txt for SEO

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://murgacorrelavoz.com.ar/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://murgacorrelavoz.com.ar/</loc>
+    <lastmod>2026-04-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- `public/robots.txt` — permite a Google crawlear todo, apunta al sitemap
- `public/sitemap.xml` — sitemap básico con solo la home (SPA, no hay rutas estáticas)

## Para Google Search Console
Una vez mergeado, en Search Console:
1. Ir a "Sitemaps" → poner `sitemap.xml` → click "Submit"
2. Google va a crawlear y confirmar que lo encontró