### PR TITLE
chore: fix vercel.json to serve static sitemap and robots

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "rewrites": [
+    { "source": "/(sitemap.xml|robots.txt)", "destination": "/$1" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- Fix vercel.json para servir sitemap.xml y robots.txt como archivos estáticos
- Antes: todo iba a index.html (404 en sitemap)
- Ahora: sitemap y robots se sirven correctamente

## Testing
- ✅ Build pasa
- ✅ sitemap.xml accesible en `/sitemap.xml`
- ✅ robots.txt accesible en `/robots.txt`