### PR TITLE
fix: update robots.txt and sitemap.xml to use www domain

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://murgacorrelavoz.com.ar/sitemap.xml
+Sitemap: https://www.murgacorrelavoz.com.ar/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://murgacorrelavoz.com.ar/</loc>
+    <loc>https://www.murgacorrelavoz.com.ar/</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>


### PR DESCRIPTION
## Fix

Update `robots.txt` and `sitemap.xml` to use `www.murgacorrelavoz.com.ar` consistently, matching the Vercel redirect configuration.

### Changes
- `robots.txt`: Update Sitemap URL to use www
- `sitemap.xml`: Update loc URL to use www

This prevents Facebook/OG crawlers from getting confused by the 307 redirect when scraping the non-www domain.