### PR TITLE
chore: add fix/ to branch-check and remove v prefix from release workflow

### DIFF
--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Validate branch name
         run: |
           branch=${{ github.head_ref }}
-          pattern='^(main|develop|feature/|release/|hotfix/|docs/|chore/|backport/)'
+          pattern='^(main|develop|feature/|fix/|release/|hotfix/|docs/|chore/|backport/)'
           if ! echo "$branch" | grep -Eq "$pattern"; then
             echo "Branch name must follow Gitflow convention!"
-            echo "Valid: feature/123-desc, feature/desc, docs/update, hotfix/123-fix, chore/desc, backport/v1.0.0"
+            echo "Valid: feature/123-desc, feature/desc, fix/123-bug, fix/bug, docs/update, hotfix/123-fix, chore/desc, backport/v1.0.0"
             echo "Note: Issue number is optional."
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,8 @@ jobs:
         if: steps.version.outputs.type == 'release'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: Release v${{ steps.version.outputs.version }}
+          tag_name: ${{ steps.version.outputs.version }}
+          name: Release ${{ steps.version.outputs.version }}
           generate_release_notes: true
           draft: false
         env:
@@ -94,7 +94,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           TYPE="${{ steps.version.outputs.type }}"
-          BACKPORT_BRANCH="backport/v${VERSION}"
+          BACKPORT_BRANCH="backport/${VERSION}"
           
           # Configuramos un usuario de git genérico de actions bot
           git config user.name "github-actions[bot]"
@@ -115,14 +115,14 @@ jobs:
           fi
           
           git add -A
-          git commit -m "chore: backport v${VERSION} to develop"
+          git commit -m "chore: backport ${VERSION} to develop"
           git push -u origin "$BACKPORT_BRANCH"
           
           # Usamos GitHub CLI para crear el PR contra develop
           gh pr create \
             --base develop \
             --head "$BACKPORT_BRANCH" \
-            --title "chore: backport v${VERSION} to develop" \
-            --body "Este PR fue generado automáticamente al lanzar el release \`v${VERSION}\`. Mergea este PR para mantener \`develop\` sincronizado con \`main\` y actualizar el historial."
+            --title "chore: backport ${VERSION} to develop" \
+            --body "Este PR fue generado automáticamente al lanzar el release \`${VERSION}\`. Mergea este PR para mantener \`develop\` sincronizado con \`main\` y actualizar el historial."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://murgacorrelavoz.com.ar/sitemap.xml
+Sitemap: https://www.murgacorrelavoz.com.ar/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://murgacorrelavoz.com.ar/</loc>
+    <loc>https://www.murgacorrelavoz.com.ar/</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>


### PR DESCRIPTION
## Changes

### branch-check.yml
- Add `fix/` to allowed branch name pattern
- Update error message to include `fix/` examples

### ci.yml
- Remove `v` prefix from GitHub Release tag_name and name
- Remove `v` prefix from backport branch name
- Remove `v` prefix from backport commit message and PR title/body

## Why

- `fix/` branches were being rejected by branch-check workflow
- Tags and releases should match the version in package.json without `v` prefix (e.g. `0.0.6` instead of `v0.0.6`)
- Consistency between branch names, tags, and release names