### PR TITLE
chore: fix release workflow to run on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,14 @@ concurrency:
 
 permissions:
   contents: write
-  pull-requests: write # Permiso necesario para que el bot pueda crear el PR
+  pull-requests: write
 
 jobs:
   build:
-    # Evitamos que el build corra cuando el PR se cierra (el push a main ya dispara un build)
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    
+
     steps:
       - uses: actions/checkout@v4
 
@@ -46,38 +45,38 @@ jobs:
       - run: npm run build
 
   release:
-    # Ejecutar solo si:
-    # 1. Es un evento de PR
-    # 2. El PR fue cerrado
-    # 3. El PR fue mergeado
-    # 4. Se mergeó hacia la rama 'main'
-    # 5. La rama de origen era 'release/*' o 'hotfix/*'
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.base_ref == 'main' && (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/'))
+    # Ejecutar solo en push a main cuando el commit sea un merge de release/* o hotfix/*
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && (startsWith(github.event.head_commit.message, 'release:') || startsWith(github.event.head_commit.message, 'hotfix:'))
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: main
 
-      - name: Extract version
+      - name: Extract version and type
         id: version
         run: |
-          BRANCH="${{ github.head_ref }}"
-          # Detect branch type
-          if [[ "$BRANCH" == release/* ]]; then
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+
+          # Detectar tipo por el mensaje del commit
+          if [[ "$COMMIT_MSG" == release:* ]]; then
             TYPE="release"
           else
             TYPE="hotfix"
           fi
           echo "type=$TYPE" >> $GITHUB_OUTPUT
-          
-          # Extract version from branch name
-          VERSION=${BRANCH#release/}
-          VERSION=${VERSION#hotfix/}
-          VERSION=${VERSION#v}
+
+          # Extraer versión de package.json (ya fue bumpeda en la rama release/hotfix)
+          VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create Git Tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git tag "$VERSION"
+          git push origin "$VERSION"
 
       - name: Create GitHub Release
         if: steps.version.outputs.type == 'release'
@@ -95,30 +94,29 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           TYPE="${{ steps.version.outputs.type }}"
           BACKPORT_BRANCH="backport/${VERSION}"
-          
+
           # Configuramos un usuario de git genérico de actions bot
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          
-          # Fetch develop as base (not main!)
+
+          # Fetch develop como base
           git fetch origin develop:develop
           git checkout develop
           git checkout -b "$BACKPORT_BRANCH"
-          
+
           if [ "$TYPE" = "release" ]; then
-            # RELEASE: Cherry-pick only the version bump commit (latest commit)
-            git cherry-pick HEAD --no-commit
+            # RELEASE: Cherry-pick solo el commit de version bump (último commit de main)
+            git cherry-pick main --no-commit
           else
-            # HOTFIX: Cherry-pick commits not in main
-            MAIN_SHA=$(git rev-parse main)
-            git log --not $MAIN_SHA --format=%H | xargs -I {} git cherry-pick {} --no-commit
+            # HOTFIX: Cherry-pick commits que están en main pero no en develop
+            git log --reverse --format=%H develop..main | xargs -I {} git cherry-pick {} --no-commit
           fi
-          
+
           git add -A
           git commit -m "chore: backport ${VERSION} to develop"
           git push -u origin "$BACKPORT_BRANCH"
-          
-          # Usamos GitHub CLI para crear el PR contra develop
+
+          # Crear PR contra develop
           gh pr create \
             --base develop \
             --head "$BACKPORT_BRANCH" \


### PR DESCRIPTION
## Fix

Change the release workflow trigger from `pull_request: closed` to `push: branches: [main]`.

### Problem
The `concurrency: cancel-in-progress: true` setting caused the release job to be cancelled when the `push` event fired simultaneously with the `pull_request: closed` event (both targeting `main`).

### Solution
Run the release job on `push` to `main`, detecting release/hotfix merges by the commit message (`release:` or `hotfix:` prefix). Read version directly from `package.json` instead of parsing branch names.

### Changes
- Release job now triggers on `push` to `main` with commit message filter
- Version extracted from `package.json` (already bumped in release/hotfix branch)
- Tag created without `v` prefix
- GitHub Release created without `v` prefix
- Backport branch naming without `v` prefix
- Fixed hotfix cherry-pick range: `develop..main` instead of broken `--not develop`