### PR TITLE
chore: remove 'Refugio' from meta descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,14 +7,14 @@
   <title>Murga Correla Voz - Tandil | Murga, familia y amigos.</title>
 
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Murga de Tandil. Trinchera de memoria colectiva. Refugio. Encendemos la calle, el fuego del carnaval, abrazo que reconforta, la que te pinta la mirada de sueños." />
+  <meta name="description" content="Murga de Tandil. Trinchera de memoria colectiva. Encendemos la calle, el fuego del carnaval, abrazo que reconforta, la que te pinta la mirada de sueños." />
   <meta name="keywords" content="murga, Tandil, carnaval, Correla Voz, cultura popular, baile, música" />
   <link rel="canonical" href="https://www.murgacorrelavoz.com.ar" />
   <meta name="robots" content="index, follow" />
 
   <!-- Open Graph Tags -->
   <meta property="og:title" content="Murga Correla Voz - Tandil | Murga, familia y amigos." />
-  <meta property="og:description" content="Murga de Tandil. Trinchera de memoria colectiva. Refugio. Encendemos la calle, el fuego del carnaval, abrazo que reconforta, la que te pinta la mirada de sueños." />
+  <meta property="og:description" content="Murga de Tandil. Trinchera de memoria colectiva. Encendemos la calle, el fuego del carnaval, abrazo que reconforta, la que te pinta la mirada de sueños." />
   <meta property="og:image" content="https://www.murgacorrelavoz.com.ar/images/og-image.jpg" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -26,7 +26,7 @@
   <!-- Twitter Card Tags -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Murga Correla Voz - Tandil | Murga, familia y amigos." />
-  <meta name="twitter:description" content="Murga de Tandil. Trinchera de memoria colectiva. Refugio. Encendemos la calle, el fuego del carnaval, abrazo que reconforta, la que te pinta la mirada de sueños." />
+  <meta name="twitter:description" content="Murga de Tandil. Trinchera de memoria colectiva. Encendemos la calle, el fuego del carnaval, abrazo que reconforta, la que te pinta la mirada de sueños." />
   <meta name="twitter:image" content="https://www.murgacorrelavoz.com.ar/images/og-image.jpg" />
 
   <!-- Favicon -->
@@ -52,7 +52,7 @@
         "@id": "https://www.murgacorrelavoz.com.ar/#website",
         "url": "https://www.murgacorrelavoz.com.ar",
         "name": "Murga Correla Voz - Tandil | Murga, familia y amigos.",
-        "description": "Murga de Tandil. Trinchera de memoria colectiva. Refugio. Encendemos la calle, el fuego del carnaval, abrazo que reconforta, la que te pinta la mirada de sueños.",
+        "description": "Murga de Tandil. Trinchera de memoria colectiva. Encendemos la calle, el fuego del carnaval, abrazo que reconforta, la que te pinta la mirada de sueños.",
         "inLanguage": "es-AR"
       },
       {


### PR DESCRIPTION
## Change

Remove the word "Refugio." from all meta descriptions for a more direct and punchy tone.

### Updated descriptions

- `<meta name="description">`
- `<meta property="og:description">`
- `<meta name="twitter:description">`
- JSON-LD structured data

**Before:**
> Murga de Tandil. Trinchera de memoria colectiva. Refugio. Encendemos la calle...

**After:**
> Murga de Tandil. Trinchera de memoria colectiva. Encendemos la calle...